### PR TITLE
Sync recording name updates to PList page via BroadcastChannel

### DIFF
--- a/syncslide-websocket/js/edit-recording.js
+++ b/syncslide-websocket/js/edit-recording.js
@@ -21,6 +21,7 @@
 	// ── Rename ────────────────────────────────────────────────────────────────
 	const recNameInput = document.getElementById('recName');
 	const rid = recNameInput ? recNameInput.dataset.rid : null;
+	const pid = recNameInput ? recNameInput.dataset.pid : null;
 
 	if (recNameInput && rid) {
 		let lastSentName = recNameInput.value.trim();
@@ -39,6 +40,7 @@
 				document.title = `Edit Recording: ${newName} - SyncSlide`;
 				const h1 = document.getElementById('edit-rec-heading');
 				if (h1) h1.textContent = `Edit Recording: ${newName}`;
+				new BroadcastChannel('syncslide').postMessage({ type: 'rec-name', pid: pid, rid: rid, name: newName });
 				if (renameStatus) {
 					renameStatus.textContent = 'Recording renamed.';
 					setTimeout(() => { renameStatus.textContent = ''; }, 3000);

--- a/syncslide-websocket/js/edit-recording.js
+++ b/syncslide-websocket/js/edit-recording.js
@@ -21,7 +21,6 @@
 	// ── Rename ────────────────────────────────────────────────────────────────
 	const recNameInput = document.getElementById('recName');
 	const rid = recNameInput ? recNameInput.dataset.rid : null;
-	const pid = recNameInput ? recNameInput.dataset.pid : null;
 
 	if (recNameInput && rid) {
 		let lastSentName = recNameInput.value.trim();
@@ -40,7 +39,7 @@
 				document.title = `Edit Recording: ${newName} - SyncSlide`;
 				const h1 = document.getElementById('edit-rec-heading');
 				if (h1) h1.textContent = `Edit Recording: ${newName}`;
-				new BroadcastChannel('syncslide').postMessage({ type: 'rec-name', pid: pid, rid: rid, name: newName });
+				new BroadcastChannel('syncslide').postMessage({ type: 'rec-name', rid: rid, name: newName });
 				if (renameStatus) {
 					renameStatus.textContent = 'Recording renamed.';
 					setTimeout(() => { renameStatus.textContent = ''; }, 3000);

--- a/syncslide-websocket/templates/edit_recording.html
+++ b/syncslide-websocket/templates/edit_recording.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 <h1 id="edit-rec-heading" tabindex="-1">Edit Recording: {{ recording.name }}</h1>
-<label>Recording name: <input type="text" id="recName" data-rid="{{ recording.id }}" data-pid="{{ pres.id }}" value="{{ recording.name }}"></label>
+<label>Recording name: <input type="text" id="recName" data-rid="{{ recording.id }}" value="{{ recording.name }}"></label>
 <div aria-live="polite" aria-atomic="true" id="rename-status"></div>
 <section aria-labelledby="timing-heading">
 <h2 id="timing-heading">Edit Timing</h2>

--- a/syncslide-websocket/templates/edit_recording.html
+++ b/syncslide-websocket/templates/edit_recording.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 <h1 id="edit-rec-heading" tabindex="-1">Edit Recording: {{ recording.name }}</h1>
-<label>Recording name: <input type="text" id="recName" data-rid="{{ recording.id }}" value="{{ recording.name }}"></label>
+<label>Recording name: <input type="text" id="recName" data-rid="{{ recording.id }}" data-pid="{{ pres.id }}" value="{{ recording.name }}"></label>
 <div aria-live="polite" aria-atomic="true" id="rename-status"></div>
 <section aria-labelledby="timing-heading">
 <h2 id="timing-heading">Edit Timing</h2>

--- a/syncslide-websocket/templates/presentations.html
+++ b/syncslide-websocket/templates/presentations.html
@@ -935,6 +935,33 @@ document.querySelectorAll('.show-pwd-toggle').forEach(function (toggle) {
 			var noRecLink = item.querySelector('details p a');
 			if (noRecLink) noRecLink.textContent = name + ' stage';
 
+		} else if (ev.data.type === 'rec-name') {
+			var rid = String(ev.data.rid);
+			var name = ev.data.name;
+
+			var recLink = document.querySelector('#rec-actions-btn-' + rid);
+			if (recLink) {
+				// Find the parent pres-item row via the recording's table row
+				var tr = recLink.closest('tr');
+
+				// Update the recording name link (first td > a, first text node)
+				if (tr) {
+					var nameLink = tr.querySelector('td:first-child a');
+					if (nameLink && nameLink.firstChild && nameLink.firstChild.nodeType === 3) {
+						nameLink.firstChild.textContent = name;
+					}
+				}
+
+				// Update the actions button text
+				recLink.textContent = 'Actions: ' + name;
+			}
+
+			var manageHeading = document.getElementById('manage-rec-access-heading-' + rid);
+			if (manageHeading) manageHeading.textContent = 'Manage access for ' + name;
+
+			var deleteHeading = document.getElementById('delete-rec-heading-' + rid);
+			if (deleteHeading) deleteHeading.textContent = 'Delete ' + name + '?';
+
 		} else if (ev.data.type === 'recording-added') {
 			var pid = String(ev.data.pid);
 			var item = document.querySelector('.pres-item[data-id="' + pid + '"]');

--- a/tests/presentations.spec.js
+++ b/tests/presentations.spec.js
@@ -543,3 +543,45 @@ test.describe('editor sees actions menu', () => {
         await editorCtx.close();
     });
 });
+
+test.describe('recording name BroadcastChannel sync', () => {
+    // BroadcastChannel only reaches pages in the same browser context (same origin).
+    // Both pages must share a context; the default { page } fixture creates isolated contexts.
+    test('rec-name broadcast updates name link, actions button, manage-access heading, and delete heading on PList', async ({ browser }) => {
+        const ctx = await browser.newContext();
+        const plistPage = await ctx.newPage();
+        const editPage = await ctx.newPage();
+
+        try {
+            // Establish an absolute base before using loginAsAdmin (which uses relative URLs).
+            await plistPage.goto('http://localhost:5003');
+            await loginAsAdmin(plistPage);
+            await editPage.goto('http://localhost:5003');
+            await loginAsAdmin(editPage);
+
+            // Open PList so the BroadcastChannel handler is active.
+            await plistPage.goto('http://localhost:5003/user/presentations');
+            // Seeded Demo recording (rid=1) elements are in the DOM even if <details> is collapsed.
+            await expect(plistPage.locator('#rec-actions-btn-1')).toBeAttached();
+
+            // Open the edit-recording page for the seeded Demo recording (pid=1, rid=1).
+            await editPage.goto('http://localhost:5003/admin/1/1/edit');
+
+            // Rename the recording.
+            const newName = 'BC Sync Test Recording';
+            await editPage.fill('#recName', newName);
+            await editPage.keyboard.press('Enter');
+
+            // Wait for the rename to succeed on the edit page before checking PList.
+            await expect(editPage.locator('#rename-status')).toContainText('Recording renamed.');
+
+            // All four PList elements must reflect the new name.
+            await expect(plistPage.locator('#rec-actions-btn-1')).toHaveText('Actions: ' + newName);
+            await expect(plistPage.locator('tr:has(#rec-actions-btn-1) td:first-child a')).toContainText(newName);
+            await expect(plistPage.locator('#manage-rec-access-heading-1')).toHaveText('Manage access for ' + newName);
+            await expect(plistPage.locator('#delete-rec-heading-1')).toHaveText('Delete ' + newName + '?');
+        } finally {
+            await ctx.close();
+        }
+    });
+});


### PR DESCRIPTION
When a recording is renamed on the edit-recording page, the PList page
now receives the update and refreshes the recording name link, actions
button, manage-access heading, and delete-confirmation heading — matching
the existing behavior for presentation name updates.

https://claude.ai/code/session_019eL1bMrE3B1LnZX6FJMeYc